### PR TITLE
Fix some environment variable related bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "main": "index.js",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "glob": "^7.1.6",
     "inquirer": "^7.0.6",
     "strava-v3": "^2.0.5",

--- a/scripts/generate-token.js
+++ b/scripts/generate-token.js
@@ -76,7 +76,7 @@ const generateToken = async () => {
     envFiles.forEach(file => {
       fs.appendFileSync(
         file,
-        `GATSBY_SOURCE_GOOGLE_DOCS_TOKEN=${JSON.stringify(token)}\n`
+        `GATSBY_SOURCE_STRAVA_TOKEN=${JSON.stringify(token)}\n`
       )
     })
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,6 +2,10 @@ const getActivities = require("./utils/activities.js")
 const getAthlete = require("./utils/athlete.js")
 const {strava} = require("./utils/strava.js")
 
+const dotenv = require("dotenv")
+
+dotenv.config()
+
 exports.sourceNodes = async (
   {actions, createNodeId, createContentDigest, reporter, cache},
   pluginOptions = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,6 +876,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
Thanks for this really cool plugin, it's going to save me a lot of work.

However, I ran into a couple issues. The script sets the `GATSBY_SOURCE_GOOGLE_DOCS_TOKEN` variable in `.env` instead of `GATSBY_SOURCE_STRAVA_TOKEN`.

Additionally, `GATSBY_SOURCE_STRAVA_TOKEN` isn't loaded from `.env` when gatsby's server-side scripts are run, as described in their [docs](https://www.gatsbyjs.org/docs/environment-variables/#server-side-nodejs), so I manually loaded them using `dotenv`. 