### PR TITLE
Fix generate-token script incorrectly naming variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strava",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "Gatsby plugin to use Strava as a data source",
   "repository": "https://github.com/xuopled/gatsby-source-strava",
   "author": "Cédric Delpoux",

--- a/scripts/generate-token.js
+++ b/scripts/generate-token.js
@@ -76,7 +76,7 @@ const generateToken = async () => {
     envFiles.forEach(file => {
       fs.appendFileSync(
         file,
-        `GATSBY_SOURCE_GOOGLE_DOCS_TOKEN=${JSON.stringify(token)}\n`
+        `GATSBY_SOURCE_STRAVA_TOKEN=${JSON.stringify(token)}\n`
       )
     })
 

--- a/src/utils/strava.js
+++ b/src/utils/strava.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const stravaApi = require("strava-v3")
 const errors = require("request-promise/errors")
 


### PR DESCRIPTION
Fixes two issues with the token script:

1. The environment variable is incorrectly named
2. node is not able to read the .env file

For the second issue, we can just require `dotenv` directly, since according to [the Gatsby docs](https://www.gatsbyjs.org/docs/environment-variables/#server-side-nodejs), `dotenv` is already a dependency of Gatsby.